### PR TITLE
Increase collection banner description height from 120px to 555px

### DIFF
--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -53,7 +53,7 @@
 
 {%- style -%}
   .collection-hero__description.to-expand {
-    max-height: 120px;
+    max-height: 555px;
     
   }
 
@@ -92,7 +92,7 @@
   if (collectionHeroEl && collectionReadMoreEl) {
     const collectionHeroHeight = collectionHeroEl.getBoundingClientRect().height;
 
-    if (collectionHeroHeight > 300) {
+    if (collectionHeroHeight > 555) {
       collectionHeroEl.classList.add('to-expand');
     }
     


### PR DESCRIPTION
## Summary

- Increased the `max-height` of the collection category description from `120px` to `555px` in `sections/main-collection-banner.liquid`
- Updated the JavaScript threshold for triggering the truncation from `300px` to `555px`, so the "Leggi di più..." button only appears when the description content genuinely exceeds the new cutoff height

## Motivation

The previous default height of `120px` was too short, cutting off category descriptions too aggressively and forcing users to click "Leggi di più..." even for moderately sized content. The new height of `555px` provides more breathing room, allowing most descriptions to display in full while still collapsing unusually long ones.

## Changes

| File | Change |
|------|--------|
| `sections/main-collection-banner.liquid` | `max-height: 120px` → `max-height: 555px` |
| `sections/main-collection-banner.liquid` | JS threshold `> 300` → `> 555` |

## How it works

The section uses a CSS class (`to-expand`) toggled by JavaScript to control whether a description is clamped:

1. On page load, the script measures the full rendered height of `.collection-hero__description`.
2. If the height exceeds the threshold (now `555px`), the `to-expand` class is added, which applies `max-height: 555px` and shows the gradient overlay with the "Leggi di più..." button.
3. Clicking the button removes `to-expand`, revealing the full description.

Both values were updated in sync to ensure the button never appears on content that isn't actually being clipped.

## Test plan

- [ ] Visit a collection page with a short description — no "Leggi di più..." button should appear
- [ ] Visit a collection page with a long description (taller than 555px) — description should be clipped at 555px with the button visible
- [ ] Click "Leggi di più..." — full description should expand correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)