### PR TITLE
Add agent documentation and autonomous preview tooling

### DIFF
--- a/.claude/hooks/docs-reminder.sh
+++ b/.claude/hooks/docs-reminder.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Stop hook: nudge the agent to fold what it learned back into the docs.
+#
+# Fires at most ONCE per session, and only when theme files changed while
+# AGENTS.md / CLAUDE.md / docs/ did not. Staying quiet is the common case.
+#
+# See AGENTS.md § "Keeping the docs alive".
+
+set -uo pipefail
+
+input=$(cat)
+session_id=$(printf '%s' "$input" | jq -r '.session_id // "unknown"' 2>/dev/null || echo unknown)
+
+sentinel="${TMPDIR:-/tmp}/claude-uem-docs-reminder-${session_id}"
+[ -e "$sentinel" ] && exit 0
+
+repo=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo" || exit 0
+
+changed=$(git status --porcelain 2>/dev/null) || exit 0
+[ -z "$changed" ] && exit 0
+
+paths=$(printf '%s\n' "$changed" | awk '{ $1=""; sub(/^ +/,""); print }')
+
+theme_changed=$(printf '%s\n' "$paths" \
+  | grep -Eq '^(assets|sections|snippets|layout|blocks|templates|config|locales|scripts)/|^(package\.json|shopify\.theme\.toml|\.theme-check\.yml)$' \
+  && echo yes || echo no)
+
+docs_changed=$(printf '%s\n' "$paths" \
+  | grep -Eq '^(docs/|AGENTS\.md|CLAUDE\.md)' \
+  && echo yes || echo no)
+
+[ "$theme_changed" = "yes" ] && [ "$docs_changed" = "no" ] || exit 0
+
+: > "$sentinel"
+
+cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "Docs check (fires once per session; theme files changed, docs did not).\n\nDid this session turn up anything durable — a better way to preview or debug something, a documented command or path that was wrong, an undocumented convention or constraint, a new piece of drift?\n\nIf yes: update docs/PREVIEW.md, docs/ARCHITECTURE.md, or AGENTS.md per the protocol in AGENTS.md, then finish.\n\nIf no — which is the common case for routine edits — say so in one line and stop. Do not invent a doc change to satisfy this check."
+}
+JSON

--- a/.claude/hooks/guard-upstream.sh
+++ b/.claude/hooks/guard-upstream.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: never open a PR or push against Shopify/dawn.
+#
+# This repo is a fork. `upstream` points at Shopify/dawn and must stay
+# fetch-only — it exists so we can diff and replay Dawn releases, nothing more.
+# On 2026-07-26 a PR was opened against Shopify/dawn by accident because `gh`
+# had no default repo and resolved to upstream. This makes that impossible.
+#
+# Denies:  gh pr/issue create (and other writes) aimed at Shopify/dawn
+#          gh pr create without an explicit --repo unicomultiplo/dawn
+#          git push to upstream / any Shopify remote
+# Allows:  git fetch upstream, git merge upstream/*, git log upstream/*,
+#          gh pr view|list|checks --repo Shopify/dawn  (read-only)
+#
+# Regression tests:  bash .claude/hooks/guard-upstream.test.sh
+# Run them after ANY change here — the allow cases matter as much as the denies.
+
+set -uo pipefail
+
+cmd=$(cat | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+[ -z "$cmd" ] && exit 0
+
+deny() {
+  jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# Strip heredoc BODIES before matching. Otherwise a commit message that merely
+# quotes a blocked command (`git push upstream`) is read as the command itself —
+# which blocked a real commit on 2026-07-26.
+stripped=$(printf '%s\n' "$cmd" | awk '
+  skip { if ($0 == mark) skip = 0; next }
+  {
+    print
+    if (match($0, /<<-?[[:space:]]*['"'"'"]?[A-Za-z_][A-Za-z0-9_]*['"'"'"]?/)) {
+      m = substr($0, RSTART, RLENGTH)
+      sub(/^<<-?[[:space:]]*/, "", m)
+      gsub(/['"'"'"]/, "", m)
+      mark = m; skip = 1
+    }
+  }
+')
+
+# Normalise whitespace for matching.
+c=$(printf '%s' "$stripped" | tr '\n' ' ' | tr -s ' ')
+
+upstream_slug='[Ss]hopify/dawn'
+
+# 1. Any gh write verb aimed at Shopify/dawn.
+if printf '%s' "$c" | grep -Eq "gh (pr|issue|release|api)\b" \
+   && printf '%s' "$c" | grep -Eq "$upstream_slug" \
+   && printf '%s' "$c" | grep -Eqv "gh (pr|issue) (view|list|checks|diff|status)\b"; then
+  deny "Blocked: this command targets Shopify/dawn, the public upstream Dawn repo.
+
+This repo is a FORK. PRs and issues belong on unicomultiplo/dawn only.
+\`upstream\` exists solely to fetch and diff Dawn releases.
+
+Use: gh pr create --repo unicomultiplo/dawn --base main ...
+Read-only queries against upstream (gh pr view/list/checks) are allowed."
+fi
+
+# 2. gh pr create without an explicit correct --repo. `gh` resolves an ambiguous
+#    default to whichever remote it likes; being explicit is the whole fix.
+if printf '%s' "$c" | grep -Eq 'gh pr create\b' \
+   && ! printf '%s' "$c" | grep -Eq '(--repo[= ]+|-R )unicomultiplo/dawn\b'; then
+  deny "Blocked: \`gh pr create\` without an explicit --repo.
+
+This repo has two remotes (origin=unicomultiplo/dawn, upstream=Shopify/dawn).
+Without --repo, gh can resolve to the public upstream — which has happened.
+
+Re-run with: gh pr create --repo unicomultiplo/dawn --base main --head <branch> ..."
+fi
+
+# 3. git push anywhere near upstream / Shopify.
+if printf '%s' "$c" | grep -Eq 'git +push\b' \
+   && printf '%s' "$c" | grep -Eq "(\bupstream\b|$upstream_slug)"; then
+  deny "Blocked: never push to \`upstream\` (Shopify/dawn).
+
+Push to origin instead:  git push -u origin <branch>"
+fi
+
+exit 0

--- a/.claude/hooks/guard-upstream.test.sh
+++ b/.claude/hooks/guard-upstream.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test battery for .claude/hooks/guard-upstream.sh
+cd "$(git rev-parse --show-toplevel)" || exit 1
+HOOK=.claude/hooks/guard-upstream.sh
+UP="Sho""pify/dawn"
+
+t() { # $1 = expected, $2 = label, $3 = command
+  r=$(printf '%s' "{\"tool_input\":{\"command\":$(jq -Rn --arg c "$3" '$c')}}" | "$HOOK" 2>&1)
+  d=$(printf '%s' "$r" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null)
+  [ -z "$d" ] && d=ALLOW
+  [ "$d" = "$1" ] && res="ok  " || res="FAIL"
+  printf '%s expected=%-6s got=%-6s | %s\n' "$res" "$1" "$d" "$2"
+}
+
+HD=$(printf 'git commit -F - <<%sMSG%s\nfix: stop git push upstream and gh pr create misuse\nSee %s for context\nMSG\ngit log -1' "'" "'" "$UP")
+t ALLOW "heredoc body merely quoting blocked commands" "$HD"
+
+HD2=$(printf 'git commit -F - <<%sMSG%s\nsome message\nMSG\ngit push upstream main' "'" "'")
+t deny "real command hidden AFTER heredoc marker" "$HD2"
+
+t deny  "push to upstream"              'git push upstream main'
+t deny  "pr create with no --repo"      'gh pr create --title x --body y'
+t deny  "pr create at upstream"         "gh pr create --repo $UP --base main"
+t deny  "issue create at upstream"      "gh issue create --repo $UP -t bug"
+t deny  "pr comment at upstream"        "gh pr comment 1 --repo $UP --body hi"
+
+t ALLOW "pr create at origin"           'gh pr create --repo unicomultiplo/dawn --base main --head x'
+t ALLOW "pr create at origin (-R)"      'gh pr create -R unicomultiplo/dawn --base main'
+t ALLOW "fetch upstream"                'git fetch upstream --tags'
+t ALLOW "merge upstream"                'git merge upstream/main'
+t ALLOW "log upstream"                  'git log --oneline upstream/main -5'
+t ALLOW "read-only pr list at upstream" "gh pr list --repo $UP"
+t ALLOW "read-only pr view at upstream" "gh pr view 3943 --repo $UP"
+t ALLOW "push to origin"                'git push -u origin docs/x'
+t ALLOW "unrelated command"             'npm run check'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/docs-reminder.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking whether the docs need updating"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(npm run check)",
+      "Bash(npm run check:fix)",
+      "Bash(npm run shot*)",
+      "Bash(npm run browser*)",
+      "Bash(npm run dev)",
+      "Bash(npm run themes)",
+      "Bash(npx agent-browser*)"
+    ],
+    "ask": [
+      "Bash(npm run pull*)",
+      "Bash(npm run push*)",
+      "Bash(npm run preview*)",
+      "Bash(npm run shopify*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-upstream.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ node_modules
 # Local development #
 #####################
 .env
+
+# Screenshots from `npm run shot` — scratch output, never committed.
+.screenshots/
+
+# Per-developer Claude Code overrides. `.claude/settings.json` IS committed.
+.claude/settings.local.json

--- a/.shopifyignore
+++ b/.shopifyignore
@@ -1,8 +1,18 @@
 # Local tooling — never upload to the store.
-node_modules/
+#
+# Use `dir/*` rather than `dir/` — the CLI warns that a bare trailing slash
+# matches unreliably.
+node_modules/*
 package.json
 package-lock.json
 shopify.theme.toml
 .env
 .env.example
+
+# Docs and agent tooling.
 CLAUDE.md
+AGENTS.md
+docs/*
+scripts/*
+.claude/*
+.screenshots/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# Working on this repo
+
+Instructions for AI coding agents. Humans are welcome to read it too — it's just
+the project's operating manual.
+
+Claude Code users: [`CLAUDE.md`](CLAUDE.md) adds a few Claude-specific notes on
+top of this file.
+
+---
+
+## What this is
+
+The Shopify theme for **unicoemultiplo.com** (store `a1cd90-81.myshopify.com`), a
+fork of [Dawn](https://github.com/Shopify/dawn) 15.5.0. Italian storefront,
+~2 600 products.
+
+Plain Liquid + CSS + JS. **No build step, no bundler, no preprocessor** — files
+upload to Shopify as-is. All tooling is local to this repo; run `npm install`
+once after cloning.
+
+Three docs, in the order you'll want them:
+
+| | |
+| --- | --- |
+| **[`docs/PREVIEW.md`](docs/PREVIEW.md)** | How to run and *see* the theme. Start here for any visual work. |
+| **[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)** | Why the theme is built this way. Read before structural changes. |
+| **[`README.md`](README.md)** | Upstream Dawn's readme, kept unmodified on purpose. Not about this store. |
+
+---
+
+## Rules
+
+**Never publish to live.** No npm script does, deliberately. Publishing happens in
+the Shopify admin, or via an explicit
+`npm run shopify -- theme push -e production --theme <id>` — and only after
+confirming with the user. `npm run dev` and `npm run push` are safe; they use a
+hidden development theme and an unpublished theme respectively.
+
+**`npm run pull` overwrites local files** with whatever is on the live theme.
+Confirm before running it, especially on a dirty tree.
+
+**Don't edit auto-generated app files.** `snippets/shogun-*.liquid` are owned by
+Shogun and will be overwritten. Same for anything else marked auto-generated.
+
+**Don't reformat Dawn files you aren't otherwise changing.** 34 files already
+differ from upstream by whitespace alone, and each one is a permanent merge
+conflict for zero gain. Turn off format-on-save for vendored files. See
+[ARCHITECTURE.md D11](docs/ARCHITECTURE.md#d11-dont-reformat-vendored-dawn-files).
+
+**Add new UI copy to both `locales/en.default.json` and `locales/it.json`**, or
+the Italian storefront falls back to English and `npm run check` flags it.
+
+**Run `npm run check` before you finish.** It's Theme Check, and it's what CI
+runs on every push.
+
+**Chrome UI uses `<span>`, not `<h2>`/`<h3>`.** Deliberate SEO convention — see
+[ARCHITECTURE.md D3](docs/ARCHITECTURE.md#d3--seo-heading-hierarchy-chrome-uses-span-not-h2h3).
+
+**Theme-editor files change under you.** `config/`, `templates/*.json` and
+`sections/*-group.json` are written by merchants in the Shopify admin and land
+here as commits titled `Update from Shopify for theme Main`. Treat them as
+merchandising data, not code.
+
+---
+
+## Doing visual work
+
+The short version — full detail in [`docs/PREVIEW.md`](docs/PREVIEW.md):
+
+```sh
+npm run dev                                   # background it; wait for the 127.0.0.1:9292 line
+npm run shot -- /products/doiy-sweetie-mug    # writes a PNG, prints the path
+```
+
+Then **look at the PNG**, edit, and re-run `npm run shot`. Liquid/CSS/JS hot-reload;
+no restart needed. Add `--mobile`, `--full`, or `--dark` as needed.
+
+Don't claim a design change works because the code looks right. Screenshot it.
+
+**On auth:** just run `npm run dev` — the CLI session is usually already cached
+and it starts without a prompt. Only if it tries to open a browser for OAuth do
+you need the user to add a Theme Access token to `.env`
+([details](docs/PREVIEW.md#auth)). Meanwhile `npm run shot -- <path> --live`
+inspects the published site.
+
+---
+
+## Keeping the docs alive
+
+**These docs are meant to be edited by you, without being asked.**
+
+The point of writing them down was so that nobody has to re-derive the same thing
+twice. That only holds if you fold what you learn back in.
+
+**When any of these happen, update the docs in the same change:**
+
+| You discovered… | Update |
+| --- | --- |
+| a faster/more reliable way to preview, screenshot, or debug something | `docs/PREVIEW.md` — **replace** the old instruction, don't append an alternative |
+| a documented command that no longer works, or a wrong URL / handle / file path | wherever it appears — fix it, don't work around it |
+| a design decision, convention, or constraint that isn't written down | `docs/ARCHITECTURE.md` §2 as a new `D<n>` entry |
+| a decision was reversed or superseded | edit that `D<n>` in place; say what changed and why |
+| new dead code, drift, or a latent bug you're not fixing now | `docs/ARCHITECTURE.md` §3 |
+| you fixed something listed in §3 | delete the entry |
+| a rule an agent should always follow | the [Rules](#rules) section above |
+| a gotcha that cost you more than a few minutes | the closest relevant section |
+
+**How to do it well:**
+
+- Write the *conclusion*, not the investigation. "Use X because Y fails on Z" —
+  not a narrative of how you found out.
+- Prefer replacing over accumulating. A doc with two competing methods is worse
+  than one with a single method that works.
+- Verify before you write. These files are load-bearing for future agents; a
+  confidently wrong line costs more than a missing one. Run the command.
+- Don't log routine work here. This is for durable facts, not a changelog.
+- Mention doc updates in your summary so the user can see what you changed.
+
+If you're unsure whether something belongs: would the next agent waste time
+without it? Then write it down.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,19 @@ Three docs, in the order you'll want them:
 
 ## Rules
 
+**PRs go to `unicomultiplo/dawn`, never to `Shopify/dawn`.** This repo is a fork;
+`upstream` is fetch-only. Always pass `--repo` explicitly — with two remotes,
+`gh` can resolve an omitted default to the public upstream, and once did:
+
+```sh
+gh pr create --repo unicomultiplo/dawn --base main --head <branch> ...
+```
+
+A committed `PreToolUse` hook blocks the unsafe forms, and `npm install` pins
+`gh`'s default repo and disables pushing to `upstream`. Fetching and diffing
+upstream stays allowed — Dawn syncs need it. See
+[ARCHITECTURE.md D14](docs/ARCHITECTURE.md#d14--upstream-is-fetch-only-prs-go-to-unicomultiplodawn).
+
 **Never publish to live.** No npm script does, deliberately. Publishing happens in
 the Shopify admin, or via an explicit
 `npm run shopify -- theme push -e production --theme <id>` — and only after

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,86 +1,54 @@
 # Unico e Multiplo — Shopify theme
 
-Dawn-based theme for the live store `a1cd90-81.myshopify.com` (public domain:
-unicoemultiplo.com). Commits titled "Update from Shopify for theme Main" come
-from Shopify's GitHub integration, i.e. edits made in the online theme editor.
+**Read [`AGENTS.md`](AGENTS.md) first.** It is the operating manual for this repo:
+what the theme is, the rules, how to preview your work, and how to keep the docs
+current. Everything there applies to you.
 
-All tooling is local to this repo — nothing is installed globally. Run
-`npm install` once after cloning.
+Then, as needed:
 
-## Previewing changes locally
+- [`docs/PREVIEW.md`](docs/PREVIEW.md) — running the theme and seeing your changes
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — why the theme is built this way
+
+This file only covers things specific to Claude Code.
+
+---
+
+## Working visually
+
+`npm run shot` writes a PNG and prints its path. **Use the Read tool on that
+path** — you can see images directly, so a screenshot is a real check, not a
+formality. Do this before reporting that a design change works.
 
 ```sh
-npm run dev
+npm run dev                                   # run_in_background: true
+npm run shot -- /products/doiy-sweetie-mug    # then Read the PNG it prints
 ```
 
-Serves the working tree at **http://127.0.0.1:9292** with hot reload, rendered
-against the real store's products, collections, metafields and settings.
+Start `npm run dev` with `run_in_background: true` and wait for the
+`127.0.0.1:9292` line before browsing. Don't foreground it — it never exits.
 
-Under the hood this uploads to a **development theme**: hidden from the theme
-list in the Shopify admin, not counted against the 20-theme limit, and deleted
-automatically after ~7 days of inactivity. **It never touches the live theme**,
-so it is safe to run against production.
+For an iterative design task, make several edits, then take one screenshot, rather
+than screenshotting after every line. Hot reload means the server keeps up.
 
-For agents:
+## Parallelism
 
-- Start it with the harness's background-run option, then wait for
-  `Preview your theme (t)` / the `127.0.0.1:9292` line in the output before
-  browsing. First start takes ~10-30s while the theme is uploaded.
-- The port is fixed at 9292 (`--port` to change it), so the preview URL is
-  predictable. Deep-link straight to the page under test, e.g.
-  `http://127.0.0.1:9292/products/<handle>`.
-- Liquid, CSS and JS edits are picked up automatically — do not restart the
-  server between edits.
-- Section/block rendering can occasionally get out of sync after schema changes;
-  restart the server rather than debugging a stale render.
+`sections/`, `snippets/` and `assets/` are largely independent — separate files,
+no shared build. Fanning subagents out across unrelated sections works well.
+`assets/base.css`, `layout/theme.liquid` and `templates/*.json` are the shared
+files; serialize edits to those.
 
-## Other scripts
+## Doc upkeep
 
-| Script | What it does | Touches the store? |
-| --- | --- | --- |
-| `npm run dev` | Local hot-reloading preview (development theme) | hidden dev theme only |
-| `npm run dev:sync` | Same, plus pulls theme-editor changes back into local files | hidden dev theme only |
-| `npm run dev:open` | Same as `dev`, opens a browser | hidden dev theme only |
-| `npm run preview` | Creates a shareable preview link for someone else | adds an **unpublished** theme |
-| `npm run push` | Uploads to a new unpublished theme | adds an **unpublished** theme |
-| `npm run pull` | Downloads the live theme's files over the working tree | read-only |
-| `npm run pull:settings` | Downloads only `config/` and `templates/` (settings + JSON templates) | read-only |
-| `npm run check` | Theme Check lint (same as CI) | no |
-| `npm run check:fix` | Theme Check with `--auto-correct` | no |
-| `npm run themes` | Lists the store's themes with IDs | read-only |
-| `npm run shopify -- <args>` | Escape hatch to the local CLI, e.g. `npm run shopify -- theme info -e production` | depends |
+[`AGENTS.md`](AGENTS.md#keeping-the-docs-alive) asks you to fold what you learn
+back into these files without being prompted. A `Stop` hook in
+`.claude/settings.json` reminds you at the end of each turn — treat it as a
+prompt to check, not an instruction to always write something. Most turns need no
+doc change; the ones that discover a better method, a stale command, or an
+undocumented constraint do.
 
-No script publishes a theme. Publishing to live is deliberately not wired up —
-do it from the Shopify admin, or with an explicit
-`npm run shopify -- theme push -e production --theme <id>` after confirming with
-the user.
+## Permissions
 
-`npm run pull` overwrites local files with whatever is on the live theme —
-confirm with the user before running it on a dirty working tree.
-
-## Store / auth
-
-The store is set once in `shopify.theme.toml` under `[environments.production]`;
-every script passes `-e production`.
-
-The first command run on a machine opens a browser for Shopify OAuth. After
-that the session is cached in `~/.config/shopify` and all commands are
-non-interactive. If a command needs to run with no cached session (CI, headless
-agent), put a Theme Access token in `.env` as `SHOPIFY_CLI_THEME_TOKEN` — see
-`.env.example`. The `.env not found. Continuing without it.` notice on every
-script is expected when no `.env` exists.
-
-## Caveats when previewing
-
-- Checkout runs on Shopify's real checkout, outside the local proxy.
-- Some third-party app scripts and analytics misbehave through the proxy. This
-  store injects the Shogun page builder via
-  `snippets/shogun-content-handler.liquid`, which wraps `content_for_header` —
-  Shogun-built pages may render differently locally than on the storefront.
-
-## Upstream
-
-`upstream` points at `Shopify/dawn`. Keep root files added for local tooling
-(`package.json`, `shopify.theme.toml`, `.shopifyignore`, this file) out of
-upstream merges' way; the Dawn `README.md` is intentionally left unmodified to
-avoid merge conflicts.
+`npm run dev`, `npm run shot`, `npm run browser` and `npm run check` are all safe
+and reversible — they never touch the live theme. `npm run pull`,
+`npm run push`, `npm run preview` and anything with `theme push` reach the store;
+confirm those with the user first.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,6 +308,31 @@ Encoded in `package.json` (commit `70703b36`):
 
 **Add a suppression only with a comment saying why.** That precedent is the point.
 
+### D14 — `upstream` is fetch-only; PRs go to `unicomultiplo/dawn`
+
+This repo is a **fork**. `upstream` (Shopify/dawn) exists solely to fetch and
+diff Dawn releases ([D1](#d1--track-dawn-as-a-remote-sync-by-squash-at-release-boundaries)).
+Nothing may be pushed or proposed to it.
+
+On 2026-07-26 a PR was opened against the public Shopify/dawn by accident: `gh`
+had no default repo configured, and with two remotes present it resolved to
+upstream. Four layers now prevent a repeat:
+
+| Layer | Covers | Where |
+| --- | --- | --- |
+| `PreToolUse` hook denies `gh pr create` without `--repo unicomultiplo/dawn`, any gh write aimed at Shopify/dawn, and `git push upstream` | Claude Code sessions | `.claude/hooks/guard-upstream.sh` (committed) |
+| `gh repo set-default unicomultiplo/dawn` | anyone using `gh` in this clone | `.git/config` — **not committed** |
+| `upstream` push URL set to a bogus value | any `git push upstream` in this clone | `.git/config` — **not committed** |
+| This rule + [AGENTS.md](../AGENTS.md#rules) | everyone reading | committed |
+
+Because the middle two live in `.git/config`, which git does not share, every
+clone must run them. `npm install` does it automatically via the `prepare`
+script; `npm run setup:remotes` re-applies them by hand. Both are idempotent.
+
+**Read-only queries against upstream stay allowed** — `git fetch upstream`,
+`git merge upstream/main`, `gh pr list --repo Shopify/dawn`. Only writes are
+blocked, because Dawn syncs depend on fetching.
+
 ---
 
 ## 3. Known drift & cleanup backlog

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,388 @@
+# Architecture & design decisions
+
+Why this theme is built the way it is. Read this before changing anything
+structural — most of what looks odd here is deliberate, and the parts that
+aren't are listed in [Known drift](#known-drift--cleanup-backlog).
+
+**Keep this file current.** See the maintenance protocol in
+[`AGENTS.md`](../AGENTS.md#keeping-the-docs-alive).
+
+---
+
+## 1. What this is
+
+A fork of [Shopify Dawn](https://github.com/Shopify/dawn) **15.5.0**
+(`config/settings_schema.json` → `theme_version`) powering
+[unicoemultiplo.com](https://unicoemultiplo.com) (store `a1cd90-81.myshopify.com`)
+— an Italian design / homeware retailer, ~2 600 products.
+
+Three parties write to this repo:
+
+| Author | How it arrives | Touches |
+| --- | --- | --- |
+| Developers / agents | PRs on `main` | everything |
+| Shopify theme editor | commits titled `Update from Shopify for theme Main`, via the Shopify GitHub integration | `config/`, `templates/`, `sections/*-group.json` |
+| Storefront apps (Shogun, GemPages, PageFly, Rewind) | written into the theme by the app, then synced down | `snippets/`, `layout/`, some `templates/` |
+
+That third row is the single most important thing to internalise: **files can
+appear in this repo that no one on the team wrote**, and some are marked
+"auto-generated, may be rewritten at any time". Editing those is pointless.
+
+### Divergence from upstream, in numbers
+
+`git diff v15.5.0 HEAD --stat` → 226 files, +53 426 / −999. Broken down:
+
+- **~150 `templates/*.json`** (~48 000 lines) — theme-editor merchandising output, not code.
+- **46 genuinely modified** code files in `assets/ sections/ snippets/ layout/ blocks/`.
+- **34 code files that differ from upstream by formatting alone** — see [D11](#d11-dont-reformat-vendored-dawn-files).
+
+---
+
+## 2. Decision log
+
+### D1 — Track Dawn as a remote; sync by squash at release boundaries
+
+`upstream` = `https://github.com/Shopify/dawn.git`. Syncs land as a single
+squashed commit (`ec8b4825` for 15.5.0).
+
+**Consequence:** upstream tags are *not* ancestors of `HEAD`
+(`git merge-base --is-ancestor v15.5.0 HEAD` is false), so `git merge upstream/main`
+will not work cleanly. Every future sync is a manual re-application: diff the new
+Dawn release against the old one, then replay onto this tree, resolving against
+the 46 modified files.
+
+Dawn's `README.md` is deliberately left unmodified to avoid a guaranteed conflict
+on every sync. Repo-local tooling (`package.json`, `shopify.theme.toml`,
+`.shopifyignore`, `AGENTS.md`, `CLAUDE.md`, `docs/`, `scripts/`) lives at paths
+Dawn does not use, for the same reason.
+
+### D2 — Shogun is the page builder of record
+
+`snippets/shogun-content-handler.liquid` is `{% include %}`d as **line 1** of
+`layout/theme.liquid` and `layout/password.liquid`, before `<!doctype html>`.
+
+It resolves the current `article | page | product | collection` into a `content`
+variable and then re-`{% capture %}`s Shopify's reserved output variables:
+
+1. appends `{% render 'shogun-products', content: content %}` to `content_for_header` — on **every page**;
+2. appends per-`template.suffix` head HTML from `content.metafields.shogun.json_template_snippets`;
+3. if `content.metafields.shogun.json_template_html_wrapper` exists, **replaces `content_for_layout` entirely**;
+4. if `content.metafields.shogun.json_template_optimizer` exists, wraps head and body in `<template id="shogun-variant-head|body">` so Shogun's JS decides what renders.
+
+**Accepted costs**, in exchange for merchant-editable landing pages:
+
+- Rewriting `content_for_header` is unsupported by Shopify. `.theme-check.yml`
+  suppresses `ContentForHeaderModification` for this one file, with a comment.
+- The file is auto-generated. **Do not edit it** — Shogun will overwrite it.
+- Which pages are Shogun-driven is **metafield-driven per resource** and therefore
+  not knowable from this repo.
+- `snippets/shogun-products.liquid` inlines up to 20 full `product | json` objects
+  plus a paginated dump of every product in listed collections into `<head>`. On
+  collection-heavy pages this is a real LCP/TTFB cost.
+
+**Debugging rule:** if a page renders empty, doubled, or ignores your
+`sections/*.liquid` edit, look for `<template id="shogun-variant-body">` in the
+DOM. Step 4 fired and the theme's own markup is inert. Test design changes on a
+resource without `shogun.*` metafields.
+
+### D3 — SEO heading hierarchy: chrome uses `<span>`, not `<h2>`/`<h3>`
+
+Across 12 files — `announcement-bar`, `header`, `header-drawer`, `footer`,
+`cart-drawer`, `main-cart-footer`, `facets`, `main-collection-product-grid`,
+`main-search`, `predictive-search`, `card-collection` — every non-content heading
+("Country", "Language", "Sort by", "Filter by", "Your cart", "Estimated total",
+collection card titles) was demoted to `<span>` **keeping the original class
+names**, so styling is untouched.
+
+Companion changes with the same motive: the duplicate `<h2 class="h1">` product
+title link removed from `sections/main-product.liquid`; `snippets/pagination.liquid`
+strips `?page=1` from the page-1 link; `templates/robots.txt.liquid` blocks facet
+params.
+
+**Accepted trade-off:** several of these were the accessible name for a landmark
+or form. `<span id=…>` still satisfies `aria-labelledby`, but the facets drawer
+and cart drawer lose heading semantics for screen-reader heading navigation.
+This was chosen knowingly — SEO over that specific a11y affordance.
+
+**If you add chrome UI, follow this convention** — use `<span>` with the heading
+class, not a real heading tag.
+
+### D4 — Percentage discount badges instead of the word "Sale"
+
+`snippets/price.liquid` and `snippets/card-product.liquid` compute
+`-{{ discount_percentage }}%` from `compare_at_price` rather than rendering
+Dawn's `products.product.on_sale` string.
+
+Incomplete: `card-product.liquid` still has other branches emitting the plain
+`on_sale` label, so badges are inconsistent by card style. See [drift](#known-drift--cleanup-backlog).
+
+### D5 — Product content comes from metafields, surfaced via `type: "liquid"` settings
+
+Rather than adding a block type per field, two schemas gained a
+`type: "liquid"` setting so merchants can write Liquid from the theme editor:
+
+- `sections/main-product.liquid` → `custom-liquid` on `collapsible_tab` blocks
+- `sections/collapsible-content.liquid` → `liquid_content` on `collapsible_row` blocks
+
+This is load-bearing: the product page's entire "Caratteristiche" spec table is a
+`liquid_content` block reading `product.metafields.shopify.material`,
+`custom.lunghezza`, `custom.altezza_2`, `custom.profondita`, `custom.diametro_2`,
+`custom.designer`, `custom.capacit_`. There are 6 `custom_liquid` blocks in the
+main product section and 46 `custom-liquid` sections across templates.
+
+**Upside:** merchants change product presentation without a deploy.
+**Downside:** a lot of the storefront's logic lives in `templates/*.json` strings
+that no linter, formatter, or grep-for-Liquid will ever check.
+
+Two custom product blocks back this up:
+
+- **`variant_sku`** — `<p id="product-sku">` inside `<div id="sku-{{ section.id }}">`
+- **`qty_disclaimer`** — when the variant is out of stock and
+  `product.metafields.custom.banner-spedizione-in-gg` is set, prints
+  `Spedito dopo il DD/MM/YYYY`
+
+Dawn only re-renders a fixed set of section IDs on variant change, so
+`assets/product-info.js` was extended with `updateDynamic(id, html)`, called for
+`sku-${section}` and `qty-disclaimer-${section}`. **A third dynamic block needs
+another explicit call here** — this is not generic.
+
+### D6 — Merchandising is one template per collection
+
+41 hand-built `templates/collection.<suffix>.json` files rather than a generic PLP
+driven by metafields. Three families:
+
+- **Brand PLPs** — `SELETTI`, `seletti-brand`, `brandani`, `brandani-brand`, `knindustrie`, `knindustrie-brand`, `bitossi-home-sc`, `plp-brand-bitossi`, `brabantia`
+- **Category PLPs** — `bicchieri-calici`, `piatti-da-tavola`, `piatti-frutta`, `piatti-brandani`, `posate`, `tumbler`, `tovaglie-tovagliette`, `turbo-moka`, `toilet-seletti`
+- **Seasonal / gifting** — `black-friday`, `san-valentino`, `regali-pasqua`, `idee-regalo-*`, `natale-*`, `regali-{50,100,150}`, `regali-per-{lei,lui,gli-sposi}`, `regalo-{compleanno,genitori}`, `offerte-e-promo`, …
+
+Plus 15 `page.*`, 8 `article.*`, 5 `blog.*`, 3 `product.*` suffixed templates.
+Stock Dawn ships 20 templates; this theme has 85 + 7 customer templates.
+
+**Why it matters to you:** editing `sections/main-collection-product-grid.liquid`
+changes all 41. Editing one merchandised page means editing its JSON template.
+
+### D7 — Flat visual language
+
+From `config/settings_data.json`:
+
+| Token | Value |
+| --- | --- |
+| Page width | **1400 px** (Dawn default 1200) |
+| Section spacing | 16 |
+| Grid gaps | 20 / 20 |
+| Corner radius | 6 px — buttons, variant pills, inputs |
+| Borders | 1 px, full opacity, on buttons / pills / inputs |
+| **Shadows** | **all opacities 0 — the theme is entirely flat** |
+| Cards | `card` style, 0 border, 2 px radius (product/collection), no padding, left-aligned |
+| Badges | top-right, `badge_corner_radius: 40` (pill) |
+| Media | 1 px border @ 5 % opacity, 0 radius |
+| Animations | reveal-on-scroll on, hover effect `default` |
+
+**Typography:** `type_header_font` and `type_body_font` are **both `roboto_n4`**,
+both at scale 100. Headings and body are the same font at the same weight, and
+there are **no webfont files in `assets/`**. Any display typography you see on the
+site comes from Shogun pages or per-section `custom_css`. Introducing real type
+hierarchy is a settings change, not a code change.
+
+**Colour:** 19 schemes (Dawn ships 5). The brand palette:
+
+| Role | Colour |
+| --- | --- |
+| Primary accent / buttons | `#598db2` muted blue |
+| Promotional emphasis | `#f4cf5f` brand yellow |
+| Seasonal | `#cc0033` christmas red |
+| Text | `#121212` |
+| Product background | `#f5f5f5` |
+
+Mirrored as custom properties at the top of `assets/base.css`
+(`--highlight-color`, `--highlight-color-2`, `--highlight-christmas`,
+`--product-background-color`, `--highlight-color-rgb`). These are consumed from
+theme-editor `custom_css` arrays in `sections/header-group.json` and
+`templates/index.json` — **not** from Liquid. The design system is therefore half
+in CSS and half in JSON, with no single source of truth. Changing a brand colour
+means changing both.
+
+Two schemes contain the unresolved literal
+`{{ shop.brand.colors.secondary[0].foreground }}` as their value — resolved at
+render, so `scheme-1`'s background is not knowable from the file alone.
+
+### D8 — Italian-first, selectors off
+
+Storefront copy is Italian and lives in `templates/*.json`, not in translation
+keys. `enable_country_selector` / `enable_language_selector` are `false` in
+`sections/header-group.json` and in `sections/header.liquid`'s schema defaults
+(only the footer group enables them).
+
+`locales/en.default.json` is still nominally the default file. `locales/it.json`
+is the only locale with real store overrides, and two of them are load-bearing:
+
+- `shopify.links.powered_by_shopify` → **`"P.IVA IT00454960436"`** — the
+  "Powered by Shopify" footer slot is repurposed to display the Italian VAT
+  number. Invisible from the theme editor. **Do not "fix" this.**
+- `shopify.checkout.payment_gateway.cash_on_delivery_label` →
+  `"Contrassegno contanti (+ €8,00)"` — a **price hard-coded into a translation
+  string**. It will silently go stale if the COD fee changes.
+- Billing-address labels rewritten to instruct customers to email invoicing details.
+- `customer_accounts.B2B.locations.tax_id` → `"Codice fiscale / Partita IVA"`.
+
+**When adding UI copy**, add the key to **both** `locales/en.default.json` and
+`locales/it.json`, or Italian falls back to English and `npm run check` flags it.
+
+### D9 — Four custom sections, one custom block
+
+| File | Purpose | Uses |
+| --- | --- | --- |
+| `sections/separator.liquid` | horizontal rule, configurable thickness + responsive padding | 21 |
+| `sections/dual-images.liquid` | 1 large left image + 2 stacked right, each linkable | 8 |
+| `blocks/ai_gen_block_f52c25c.liquid` | "Icone prodotti cliccabili" (AI-generated; Italian `@prompt` docstring) | 3 collection templates |
+| `sections/payment-methods.liquid` | payment-icon strip | **0 — dead** |
+| `sections/disclosures.liquid` | product/cart disclosure feature | see below |
+
+These three deviate from Dawn's convention by using an inline `<style>` block
+instead of an `assets/section-*.css` file: `dual-images`, `separator`,
+`payment-methods`.
+
+The **disclosures** feature is a bespoke addition spanning
+`snippets/product-disclosures.liquid`, `snippets/cart-disclosure-indicator.liquid`,
+`assets/component-disclosures.css`, `assets/cart-disclosure-modal.js`,
+`assets/cart-disclosure-tooltip.js`, `assets/disclosures.js`.
+
+### D10 — Whole multicolumn card is clickable
+
+`sections/multicolumn.liquid` changed `.multicolumn-card` from `<div>` to `<a>`.
+Three coupled edits make it work:
+
+1. `role="none"` on the non-linked variant;
+2. `assets/base.css` → `a:not([href]):not([role="none"]) { cursor: not-allowed }`;
+3. `assets/section-multicolumn.css` → `.multicolumn-card { display: block }`.
+
+Multicolumn is the most-used section on the site (**368 instances**), so this is
+load-bearing — but the inner content still contains an `<a>` for `link_label`,
+producing **nested anchors**, which is invalid HTML that browsers silently unnest.
+
+### D11 — Don't reformat vendored Dawn files
+
+**34 code files differ from upstream Dawn 15.5.0 by formatting alone** —
+Prettier 3 style: multiline `box-shadow`/`transition`, trailing commas,
+`.5rem` → `0.5rem`, `99.630%` → `99.63%`. Zero functional change, permanent merge
+conflict on every upstream sync.
+
+Cause: `.vscode/settings.json` enables `formatOnSave` for JS and CSS with a newer
+Prettier than Shopify used to author Dawn.
+
+**Rule going forward: never save-format a Dawn file you are not otherwise
+changing.** Verify before committing:
+
+```sh
+# Files whose diff vs upstream is whitespace/comma-only
+for f in $(git diff v15.5.0 HEAD --name-only -- assets sections snippets layout blocks); do
+  [ -f "$f" ] || continue
+  [ "$(git show v15.5.0:"$f" | tr -d '[:space:],')" = "$(tr -d '[:space:],' < "$f")" ] && echo "format-only: $f"
+done
+```
+
+### D12 — Local tooling can never publish to live
+
+Encoded in `package.json` (commit `70703b36`):
+
+- `npm run push` is always `--unpublished`.
+- `npm run dev` uploads to a **hidden development theme** — invisible in the admin
+  theme list, not counted against the 20-theme limit, auto-deleted after ~7 days
+  idle. Safe against production.
+- **No script publishes.** Publishing is the admin UI, or an explicit
+  `npm run shopify -- theme push -e production --theme <id>` after confirming with
+  the store owner.
+- `.shopifyignore` keeps every tooling file off the store.
+- CI is a single `theme-check` job on every push (`.github/workflows/ci.yml`).
+
+### D13 — Three documented theme-check suppressions
+
+`.theme-check.yml`, each with a comment explaining why:
+
+| Rule | Scope | Reason |
+| --- | --- | --- |
+| `LiquidHTMLSyntaxError` | `sections/header.liquid` | dynamic tag names (`<sticky-header>` vs `<div>`) via Liquid inside the opening tag — valid Shopify Liquid the parser can't handle |
+| `ContentForHeaderModification` | `snippets/shogun-content-handler.liquid` | see [D2](#d2--shogun-is-the-page-builder-of-record) |
+| `ValidSchema` | `sections/email-signup-banner.liquid` | `templates` is a valid schema key that theme-check flags as unknown |
+| `MatchingTranslations`, `TemplateLength` | global | disabled |
+
+**Add a suppression only with a comment saying why.** That precedent is the point.
+
+---
+
+## 3. Known drift & cleanup backlog
+
+Not decisions — accumulated debt. Verified present as of 2026-07-26.
+
+**Dead code**
+
+1. **GemPages is entirely dead but still ships**: `layout/theme.gempages.{blank,header,footer}.liquid`, `layout/theme.gem-layout-none.liquid`, `snippets/gp-head.liquid` (**no caller**, verified), `assets/gp-global.css` (minified Tailwind 3.3.2 reset, loaded only by the orphaned snippet), and 3 homepage backups `templates/index.gem-*.json` / `index.gp-template-bk-default.json` (~780 lines each).
+2. **PageFly is dead**: `snippets/pagefly-main-js.liquid` (**no caller**, verified) — but its `pagefly.*` translation block was appended to **all 30 locale files**.
+3. **Rewind leftovers**: `snippets/rewind_menu_backup_do_not_delete.liquid` + `templates/page.rewind_menu_backup_do_not_delete.liquid`.
+4. `sections/payment-methods.liquid` — **0 uses**.
+5. `{% capture content_for_body %}` in `shogun-content-handler.liquid` is never output — dead code from an older Shogun version.
+
+**Correctness**
+
+6. **Trailing commas in two `{% schema %}` blocks** — `sections/collapsible-content.liquid` and `sections/dual-images.liquid` both fail `JSON.parse`. Shopify tolerates it today; it is invalid JSON.
+7. **Hyphenated Liquid identifiers** — `block.settings.custom-liquid`, `product.metafields.custom.banner-spedizione-in-gg`. Resolves today, one strict-mode change from being parsed as subtraction.
+8. **Nested `<a>`** in `multicolumn.liquid` (see [D10](#d10--whole-multicolumn-card-is-clickable)).
+9. **`-N%` badge covers only some sale-badge render paths** (see [D4](#d4--percentage-discount-badges-instead-of-the-word-sale)).
+
+**Design system**
+
+10. **`scheme-white-text` is white-on-white** and unreadable. The dated hotfix at the bottom of `assets/base.css` (`/* # Fix for the 2026-02-05 issue */`, `!important` on `.cart-remove-button` and hover states) patches the symptom, not the scheme.
+11. **`.page-width--narrow` neutered globally** in `base.css` — `max-width: 72.6rem; padding: 0` → `max-width: var(--page-width); padding: 0 5rem`. Dawn's narrow-content variant (article/page templates) is effectively gone, site-wide, rather than per-template.
+12. **All article/blog cards forced brand yellow** — `.article-card-wrapper .card, .contains-card--article { background-color: var(--highlight-color) !important }` overrides the `blog_card_color_scheme` setting.
+
+**Drifted layouts**
+
+13. The five alternate layouts (`theme.shogun.landing`, four `theme.gem*`) were cloned from an older `theme.liquid` and never re-synced. All are missing: the GTM container + noscript iframe, Dawn 15.5.0's `standard-events.js` + `PageViewEvent`, `cart-disclosure-modal.js` / `cart-disclosure-tooltip.js` / `standard-actions-override.js`, `data-template` on `<main>`, and the 15.5.0 CLS body-layout fix. **Practical impact: Shogun landing pages have no analytics.** The gap widens with every Dawn upgrade.
+
+**Untranslated / hard-coded**
+
+14. Italian strings outside the locale system: `"Leggi di più..."` (`main-collection-banner.liquid`), `"Spedito dopo il"` (`main-product.liquid`).
+15. `€8,00` COD fee inside a translation string ([D8](#d8--italian-first-selectors-off)).
+16. `main-collection-banner.liquid`'s expandable description hard-codes a `#ffffff` gradient (ignores the section colour scheme), measures height at parse time rather than `DOMContentLoaded` (so it can run before webfonts settle), and leaves an empty `.collection-hero__description__expand button {}` rule plus a `display: flex` immediately overridden by `display: none`.
+
+**Merge friction**
+
+17. 34 format-only divergences ([D11](#d11-dont-reformat-vendored-dawn-files)).
+18. All 30 Dawn buyer locales + 21 schema locales retained for a single-language store.
+
+**Historical curiosity:** `templates/robots.txt.liquid` blocks `/catalogsearch/` — a **Magento** URL pattern, left over from a pre-Shopify migration.
+
+---
+
+## 4. Where things live
+
+```
+layout/      theme.liquid ← GTM, Shogun include (line 1), global JS/CSS
+             + 5 drifted alternate layouts (see drift #13)
+sections/    58 files. main-*.liquid = a page's real content.
+             Custom: separator, dual-images, payment-methods, disclosures
+             *-group.json = header/footer, theme-editor owned
+snippets/    44 files. card-product.liquid is the product card design (~929 lines changed)
+             shogun-*.liquid = auto-generated, do not edit
+blocks/      ai_gen_block_f52c25c.liquid
+assets/      flat, no build step. base.css (global + brand tokens),
+             component-*.css, section-*.css, template-*.css, ~90 icon-*.svg
+             global.js + per-feature JS loaded by the section that needs it
+templates/   85 + 7 customer. JSON = merchandising, theme-editor owned
+config/      settings_data.json (all design settings), settings_schema.json
+locales/     30 buyer + 21 schema. en.default.json is default; it.json has the overrides
+```
+
+**Adding CSS:** sections load their own with
+`{{ 'section-foo.css' | asset_url | stylesheet_tag }}` at the top of the liquid
+file (see `sections/main-product.liquid`, `sections/main-collection-product-grid.liquid`).
+Global-only rules go in `base.css`. No preprocessor, no bundler — files upload as-is.
+
+**Heavily modified Dawn files — expect conflicts on upstream sync:**
+`sections/main-product.liquid` (effectively rewritten), `snippets/card-product.liquid`
+(~929 lines), `sections/main-collection-product-grid.liquid`, `assets/component-cart-items.css`
+(+257, rewritten), `assets/global.js` (+158), `assets/cart.js` (+144), `assets/facets.js` (+121),
+`assets/base.css` (+117), `sections/header.liquid`, `snippets/facets.liquid`.
+
+For the page-by-page "what URL, what file" map, see
+[`PREVIEW.md`](PREVIEW.md#page--file-map).

--- a/docs/PREVIEW.md
+++ b/docs/PREVIEW.md
@@ -1,0 +1,286 @@
+# Previewing & visually checking the theme
+
+How to see a change with your own eyes, without a human in the loop.
+
+**Keep this file current.** If you find a faster or more reliable way to do
+anything here, replace the instruction — see
+[`AGENTS.md`](../AGENTS.md#keeping-the-docs-alive).
+
+---
+
+## The loop
+
+```sh
+npm run dev                      # 1. start the preview (background it) — ~10-30s
+npm run shot -- /products/doiy-sweetie-mug   # 2. screenshot a page
+# 3. read the PNG it prints, edit liquid/css, re-run step 2 (no restart needed)
+```
+
+That's it. Steps 1 and 2 are explained below; everything else on this page is
+for when the simple loop isn't enough.
+
+---
+
+## 1. Start the preview server
+
+```sh
+npm run dev
+```
+
+Serves the working tree at **http://127.0.0.1:9292** with hot reload, rendered
+against the real store's products, collections, metafields and settings.
+
+Under the hood it uploads to a **development theme**: hidden from the admin theme
+list, not counted against the 20-theme limit, deleted automatically after ~7 days
+idle. **It never touches the live theme** — safe to run against production.
+
+**Running it as an agent:**
+
+- Start it with your harness's background-run option. Wait for the
+  `127.0.0.1:9292` line in the output before browsing. First start takes ~10–30 s.
+- The port is fixed, so URLs are predictable. Deep-link straight to the page under
+  test — don't navigate from the homepage.
+- Liquid, CSS and JS edits are picked up automatically. **Do not restart between
+  edits.**
+- Restart after `{% schema %}` changes — section rendering can get out of sync,
+  and a stale render is not worth debugging.
+
+### Auth
+
+**Just run it first.** The CLI caches its session in
+`~/.config/shopify-cli-kit-nodejs/` (not `~/.config/shopify/` — don't use that
+path's absence as evidence you're logged out). On a machine that has been used
+before, `npm run dev` starts with no prompt.
+
+Only if it tries to open a browser for OAuth do you need a human, one time:
+
+> Shopify admin → Apps → Theme Access → Add user → copy the emailed `shptka_…`
+> token → put it in `.env` as `SHOPIFY_CLI_THEME_TOKEN=shptka_…`
+
+`.env` is gitignored and loaded automatically by the npm scripts
+(`--env-file-if-exists`). See `.env.example`. That token also covers CI and any
+truly headless run.
+
+While you're blocked on that, `npm run shot -- <path> --live` inspects the
+published storefront — useful for "what does it look like today?", useless for
+checking your own edit.
+
+---
+
+## 2. Screenshot a page
+
+```sh
+npm run shot -- <path> [flags]
+```
+
+`scripts/shot.mjs` wraps [`agent-browser`](https://github.com/vercel-labs/agent-browser)
+with the settings this store needs every time. It opens the page, dismisses the
+cookie banner, waits for the page to settle, writes a PNG to `.screenshots/`, and
+prints the path plus any console errors. **Read the PNG** — that's the point.
+
+| Flag | Effect |
+| --- | --- |
+| *(none)* | desktop, 1440×900 |
+| `--mobile` | 390×844 |
+| `--tablet` | 820×1180 |
+| `--full` | full page, not just the viewport |
+| `--dark` | emulate `prefers-color-scheme: dark` |
+| `--live` | hit `https://unicoemultiplo.com` instead of localhost |
+| `--out path.png` | explicit output path |
+
+```sh
+npm run shot -- /                                  # homepage
+npm run shot -- /collections/seletti --mobile      # mobile PLP
+npm run shot -- /products/<handle> --full          # whole PDP
+npm run shot -- /cart --live                       # live cart, no dev server
+```
+
+Output filenames derive from the path, so desktop and mobile shots of the same
+page don't overwrite each other. `.screenshots/` is gitignored.
+
+If it reports `Nothing listening on 127.0.0.1:9292`, start the dev server.
+If Chrome fails to launch: `npm run browser:setup` (downloads Chrome for Testing
+to `~/.agent-browser/`, ~184 MB, once per machine). Diagnose with
+`npm run browser:doctor`.
+
+---
+
+## 3. Driving the browser directly
+
+`npm run shot` covers most needs. For anything interactive, use the CLI:
+
+```sh
+npm run browser -- <command>
+```
+
+This is `agent-browser` pinned to the session name `uem`, so cookies and the
+accepted cookie consent persist across calls — and across separate shell
+invocations. The browser stays alive between commands via a daemon.
+
+```sh
+npm run browser -- open http://127.0.0.1:9292/products/<handle>
+npm run browser -- snapshot -i          # accessibility tree, interactive only, gives @e1 refs
+npm run browser -- click @e4            # click by ref from the snapshot
+npm run browser -- find role button click --name "Aggiungi al carrello"
+npm run browser -- get text .price
+npm run browser -- errors               # JS errors
+npm run browser -- console              # console output
+npm run browser -- set viewport 390 844
+npm run browser -- eval "document.querySelectorAll('.card').length"
+npm run browser -- close
+```
+
+`snapshot` before `click` — refs (`@e1`, `@e2`) come from the most recent
+snapshot. `--annotate` on a screenshot overlays those same numbers on the image,
+which is the fastest way to connect what you see to what you can click.
+
+Full command list: `npx agent-browser --help`, or
+`npx agent-browser skills get core --full` for the authors' own agent guide.
+
+### Things worth knowing for this store
+
+**The cookie banner covers everything.** First run in a fresh session, dismiss it:
+
+```sh
+npm run browser -- find role button click --name "Accetta"
+```
+
+The `uem` session persists that consent, so it only happens once per machine.
+`npm run shot` does it automatically.
+
+**A WhatsApp widget sits bottom-right** on every page and will appear in
+full-page screenshots. It's an app embed, not theme code.
+
+**Shogun pages may not reflect your edits.** If a page renders empty, doubled, or
+ignores your change, check for `<template id="shogun-variant-body">`:
+
+```sh
+npm run browser -- eval "!!document.getElementById('shogun-variant-body')"
+```
+
+`true` means Shogun replaced the theme's markup and your `sections/*.liquid` edit
+cannot show up. Test on a resource without `shogun.*` metafields.
+See [ARCHITECTURE.md D2](ARCHITECTURE.md#d2--shogun-is-the-page-builder-of-record).
+
+**Some third-party app scripts and analytics misbehave through the local proxy.**
+Console noise from them is expected and not your bug.
+
+**Checkout runs on Shopify's real checkout**, outside the proxy. You cannot
+preview checkout changes locally, and you should not place test orders.
+
+---
+
+## 4. Visual regression
+
+Prove a change did what you intended and nothing else:
+
+```sh
+npm run shot -- /collections/seletti --out /tmp/before.png     # before editing
+# ... make the edit ...
+npm run shot -- /collections/seletti --out /tmp/after.png
+npm run browser -- diff screenshot --baseline /tmp/before.png
+```
+
+`diff snapshot` does the same for the accessibility tree — better than pixels for
+catching structural changes (an element that vanished, a heading that changed
+level) without false positives from image lazy-loading.
+
+Other checks worth running on a design change:
+
+```sh
+npm run browser -- vitals                # LCP / CLS / TTFB / FCP / INP
+npm run browser -- errors                # JS errors
+npm run check                            # Theme Check lint — same as CI
+```
+
+Run `npm run check` before handing work back. CI runs it on every push.
+
+---
+
+## 5. Page ↔ file map
+
+Which URL to open, and which file to edit.
+
+| To check… | Open | Edit |
+| --- | --- | --- |
+| Homepage | `/` | `templates/index.json`, `sections/slideshow.liquid`, `sections/multicolumn.liquid` |
+| Product page | `/products/doiy-sweetie-mug` | `sections/main-product.liquid`, `assets/section-main-product.css` |
+| Product cards / grid tiles | any collection URL | `snippets/card-product.liquid`, `assets/component-card.css` |
+| Collection / PLP | `/collections/cucina-e-tavola-piatti` | `sections/main-collection-product-grid.liquid`, `sections/main-collection-banner.liquid`, `assets/template-collection.css` |
+| Filters / facets | `/collections/seletti` | `snippets/facets.liquid`, `assets/component-facets.css`, `assets/facets.js` |
+| Cart page | `/cart` | `sections/main-cart-items.liquid`, `assets/component-cart-items.css` |
+| Cart drawer | any page, then add to cart | `snippets/cart-drawer.liquid`, `assets/component-cart-drawer.css` |
+| Header / nav / mega menu | any page | `sections/header.liquid`, `snippets/header-mega-menu.liquid`, `sections/header-group.json` |
+| Footer | any page | `sections/footer.liquid`, `assets/section-footer.css`, `sections/footer-group.json` |
+| Search | `/search?q=piatti` | `sections/main-search.liquid`; predictive: `sections/predictive-search.liquid` |
+| Blog index | `/blogs/apparecchiare-con-stile` | `sections/main-blog.liquid` |
+| Article | `/blogs/regalare-per-stupire/cosa-regalare-ai-genitori-per-natale` | `sections/main-article.liquid` |
+| Generic page | `/pages/i-nostri-brand` | `sections/main-page.liquid` |
+| Contact form | `/pages/i-nostri-brand?view=contact` | `sections/contact-form.liquid` |
+| 404 | `/this-does-not-exist` | `templates/404.json` (the `main-404` section is **disabled**; a rich-text block replaces it) |
+| Login / account | `/account/login` | `sections/main-login.liquid`, `assets/customer.css` |
+| Disclosures feature | product & cart pages | `snippets/product-disclosures.liquid`, `snippets/cart-disclosure-indicator.liquid`, `assets/component-disclosures.css` |
+
+### The `?view=` trick
+
+Suffixed templates render on **any** resource of that type via `?view=`:
+
+```
+/collections/<any-collection>?view=brandani-brand   → templates/collection.brandani-brand.json
+/products/<any-product>?view=bone-china             → templates/product.bone-china.json
+/pages/<any-page>?view=contact                      → templates/page.contact.json
+```
+
+This works through the dev proxy, so you can check any of the 41 collection
+templates, 15 page templates and 8 article templates **without knowing which
+resource it's assigned to in the admin.** This is the fastest way to review
+merchandised layouts.
+
+### Real handles to deep-link to
+
+Products: `doiy-sweetie-mug`, `bitossi-home-guest-piatto-pizza-mamma-mia`,
+`brandani-calipso-mug-set-2-pz-stoneware`, `1518-seletti-hybrid-vaso-melania`,
+`5074-seletti-my-moon-lamp-lampada-seduta-indoor-outdoor`,
+`joseph-joseph-ceppo-coltelli-con-forbici`, `brabantia-appendiabiti-linn`
+
+Collections: `cucina-e-tavola-piatti`, `cucina-e-tavola-bicchieri-e-calici`,
+`cucina-e-tavola-posate`, `seletti`, `brandani`, `knindustrie`, `bitossi-home`,
+`offerte-e-promo`, `idee-regalo-natale`, `vetro-borosilicato`
+
+Pages: `i-nostri-brand`, `iscrizione`, `pagamenti`, `natale`,
+`la-tavola-di-natale`, `bomboniere-brandani`
+
+Blogs: `apparecchiare-con-stile`, `regalare-per-stupire`, `blog`
+
+Navigation menus live in the Shopify admin, not this repo — but the dev server
+renders the real ones, so nav looks correct locally.
+
+---
+
+## 6. Other scripts
+
+| Script | What it does | Touches the store? |
+| --- | --- | --- |
+| `npm run dev` | local hot-reloading preview | hidden dev theme only |
+| `npm run dev:sync` | same, plus pulls theme-editor changes into local files | hidden dev theme only |
+| `npm run dev:open` | same as `dev`, opens a browser | hidden dev theme only |
+| `npm run shot` | screenshot a page for review | no |
+| `npm run browser` | drive the browser directly | no |
+| `npm run browser:setup` | download Chrome for Testing (once per machine) | no |
+| `npm run check` | Theme Check lint (same as CI) | no |
+| `npm run check:fix` | Theme Check with `--auto-correct` | no |
+| `npm run preview` | shareable preview link for a human | adds an **unpublished** theme |
+| `npm run push` | upload to a new unpublished theme | adds an **unpublished** theme |
+| `npm run pull` | **overwrites local files** with the live theme | read-only on the store |
+| `npm run pull:settings` | pull only `config/` and `templates/` | read-only on the store |
+| `npm run themes` | list the store's themes with IDs | read-only |
+| `npm run shopify -- <args>` | escape hatch to the local CLI | depends |
+
+`npm run pull` overwrites the working tree — **confirm with the user before
+running it**, especially if the tree is dirty.
+
+No script publishes to live. That is deliberate — see
+[ARCHITECTURE.md D12](ARCHITECTURE.md#d12--local-tooling-can-never-publish-to-live).
+
+The `.env not found. Continuing without it.` notice on every script is expected
+when no `.env` exists.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "unicoemultiplo-theme",
       "version": "1.0.0",
       "devDependencies": {
-        "@shopify/cli": "^3.94.3"
+        "@shopify/cli": "^3.94.3",
+        "agent-browser": "^0.27.0"
       },
       "engines": {
         "node": ">=20.10"
@@ -651,6 +652,17 @@
       },
       "engines": {
         "node": ">=20.10.0"
+      }
+    },
+    "node_modules/agent-browser": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.27.0.tgz",
+      "integrity": "sha512-mmHzVsYFVA6nshNNGJzg83aVMgKpf4h98ytY3pvtJB1Cot0ZyA2bfnkbSngGD56Azkj+GlhVH6qx9DfKOVE0yg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "agent-browser": "bin/agent-browser.js"
       }
     },
     "node_modules/boolean": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "node": ">=20.10"
   },
   "scripts": {
+    "prepare": "node scripts/setup-remotes.mjs",
+    "setup:remotes": "node scripts/setup-remotes.mjs",
     "shopify": "node --env-file-if-exists=.env node_modules/@shopify/cli/bin/run.js",
     "dev": "npm run shopify -- theme dev -e production",
     "dev:sync": "npm run shopify -- theme dev -e production --theme-editor-sync",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,14 @@
     "check": "npm run shopify -- theme check",
     "check:fix": "npm run shopify -- theme check --auto-correct",
     "themes": "npm run shopify -- theme list -e production",
-    "logout": "npm run shopify -- auth logout"
+    "logout": "npm run shopify -- auth logout",
+    "browser": "agent-browser --session-name uem",
+    "browser:setup": "agent-browser install",
+    "browser:doctor": "agent-browser doctor",
+    "shot": "node scripts/shot.mjs"
   },
   "devDependencies": {
-    "@shopify/cli": "^3.94.3"
+    "@shopify/cli": "^3.94.3",
+    "agent-browser": "^0.27.0"
   }
 }

--- a/scripts/setup-remotes.mjs
+++ b/scripts/setup-remotes.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Configure this clone so PRs and pushes can only reach unicomultiplo/dawn.
+//
+// `upstream` (Shopify/dawn) must stay fetch-only — it exists to diff and replay
+// Dawn releases, nothing more. Git and gh config live in .git/config, which is
+// NOT committed, so every clone has to run this once. Runs from `npm install`
+// via the prepare script.
+//
+// The committed PreToolUse hook in .claude/settings.json enforces the same rule
+// for Claude Code sessions. This covers humans and other tools.
+
+import { spawnSync } from 'node:child_process';
+
+const run = (cmd, args) => spawnSync(cmd, args, { encoding: 'utf8' });
+const ok = (r) => r.status === 0;
+
+if (!ok(run('git', ['rev-parse', '--git-dir']))) process.exit(0); // not a clone (e.g. tarball)
+
+const steps = [];
+
+// 1. gh: pin the default repo so `gh pr create` can never resolve to upstream.
+if (ok(run('sh', ['-c', 'command -v gh']))) {
+  if (ok(run('gh', ['repo', 'set-default', 'unicomultiplo/dawn']))) {
+    steps.push('gh default repo → unicomultiplo/dawn');
+  }
+} else {
+  steps.push('gh not installed — skipped default-repo pin');
+}
+
+// 2. git: make the upstream remote fetch-only.
+const remotes = run('git', ['remote']).stdout || '';
+if (remotes.split('\n').includes('upstream')) {
+  const DISABLED = 'DISABLED-upstream-is-fetch-only';
+  const current = (run('git', ['remote', 'get-url', '--push', 'upstream']).stdout || '').trim();
+  if (current !== DISABLED) {
+    run('git', ['remote', 'set-url', '--push', 'upstream', DISABLED]);
+    steps.push('upstream remote → fetch-only (push disabled)');
+  }
+}
+
+if (steps.length) {
+  console.log('Remote guards configured:');
+  for (const s of steps) console.log(`  • ${s}`);
+}

--- a/scripts/shot.mjs
+++ b/scripts/shot.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Screenshot a storefront page for visual review.
+//
+//   npm run shot -- /products/doiy-sweetie-mug
+//   npm run shot -- / --mobile --full
+//   npm run shot -- /collections/seletti --live
+//
+// Wraps agent-browser with the settings this store needs every time: a named
+// session (so the cookie banner stays dismissed), a fixed viewport, and a wait
+// for the page to settle. Prints the PNG path and any console errors.
+//
+// See docs/PREVIEW.md.
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BIN = resolve(ROOT, 'node_modules/.bin/agent-browser');
+const SESSION = 'uem';
+
+const LOCAL_BASE = 'http://127.0.0.1:9292';
+const LIVE_BASE = 'https://unicoemultiplo.com';
+
+const VIEWPORTS = {
+  desktop: [1440, 900],
+  tablet: [820, 1180],
+  mobile: [390, 844],
+};
+
+const argv = process.argv.slice(2);
+const flags = new Set(argv.filter((a) => a.startsWith('--')));
+const positional = argv.filter((a) => !a.startsWith('--'));
+
+const outFlagIndex = argv.indexOf('--out');
+const explicitOut = outFlagIndex !== -1 ? argv[outFlagIndex + 1] : null;
+
+if (positional.length === 0) {
+  console.error('usage: npm run shot -- <path-or-url> [--mobile|--tablet] [--full] [--dark] [--live] [--out file.png]');
+  process.exit(1);
+}
+
+const target = positional[0];
+const base = flags.has('--live') ? LIVE_BASE : LOCAL_BASE;
+const url = /^https?:\/\//.test(target) ? target : base + (target.startsWith('/') ? target : `/${target}`);
+
+const size = flags.has('--mobile')
+  ? VIEWPORTS.mobile
+  : flags.has('--tablet')
+    ? VIEWPORTS.tablet
+    : VIEWPORTS.desktop;
+
+const slug =
+  (target.replace(/^https?:\/\/[^/]+/, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '') || 'home') +
+  (flags.has('--mobile') ? '-mobile' : flags.has('--tablet') ? '-tablet' : '') +
+  (flags.has('--dark') ? '-dark' : '');
+
+const out = explicitOut ? resolve(explicitOut) : resolve(ROOT, '.screenshots', `${slug}.png`);
+mkdirSync(dirname(out), { recursive: true });
+
+/** Run agent-browser; returns {status, stdout, stderr}. Never throws. */
+function ab(args, { quiet = true } = {}) {
+  const res = spawnSync(BIN, ['--session-name', SESSION, ...args], {
+    encoding: 'utf8',
+    stdio: quiet ? 'pipe' : 'inherit',
+  });
+  return { status: res.status ?? 1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+// Fail early and usefully when the dev server is not up.
+if (!flags.has('--live')) {
+  const reachable = await fetch(LOCAL_BASE, { method: 'HEAD' }).then(
+    () => true,
+    () => false,
+  );
+  if (!reachable) {
+    console.error(`✗ Nothing listening on ${LOCAL_BASE}`);
+    console.error('  Start the preview first:  npm run dev   (background it; wait for the 127.0.0.1:9292 line)');
+    process.exit(1);
+  }
+}
+
+const open = ab(['open', url, '--viewport', `${size[0]}x${size[1]}`]);
+if (open.status !== 0) {
+  console.error(open.stderr || open.stdout);
+  console.error('\nIf Chrome failed to launch, run:  npm run browser:setup');
+  process.exit(1);
+}
+
+// `open --viewport` only applies when it launches the browser; a reused session
+// keeps the previous size. Set it explicitly, then reload so responsive images
+// and section JS re-evaluate at the new width.
+ab(['set', 'viewport', String(size[0]), String(size[1])]);
+ab(['set', 'media', flags.has('--dark') ? 'dark' : 'light']);
+ab(['reload']);
+
+// Cookie consent covers the page. Harmless no-op once the session has accepted.
+ab(['find', 'role', 'button', 'click', '--name', 'Accetta']);
+
+// Let lazy images and section JS settle before capturing.
+ab(['wait', '1200']);
+
+const shot = ab(['screenshot', ...(flags.has('--full') ? ['--full'] : []), out]);
+if (shot.status !== 0) {
+  console.error(shot.stderr || shot.stdout);
+  process.exit(1);
+}
+
+const errors = ab(['errors']).stdout.trim();
+
+console.log(`✓ ${url}`);
+console.log(`  ${size[0]}x${size[1]}${flags.has('--full') ? ' full-page' : ''}${flags.has('--dark') ? ' dark' : ''}`);
+console.log(`  ${out}`);
+if (errors && !/no (page )?errors/i.test(errors)) {
+  console.log(`\n⚠ page errors:\n${errors}`);
+}


### PR DESCRIPTION
Documents how this theme is built, and gives agents a way to actually *see* their changes rather than inferring correctness from the code.

## Docs

| File | Purpose |
| --- | --- |
| `AGENTS.md` | Tool-neutral entry point — what the theme is, the rules, the preview loop, and a protocol for keeping the docs current |
| `CLAUDE.md` | Reduced to Claude Code specifics; points at `AGENTS.md` |
| `docs/ARCHITECTURE.md` | 13 numbered design decisions with rationale and accepted trade-offs |
| `docs/PREVIEW.md` | The preview loop, a page↔file map, and the `?view=` trick |

`ARCHITECTURE.md` deliberately separates **decisions** from a **drift/cleanup backlog**, so deliberate choices don't get "fixed" and accidents don't get enshrined.

## Findings recorded

Each was verified against the tree, not taken on trust:

- **Upstream tags are not ancestors of `HEAD`** — `git merge upstream/main` will not work. Every Dawn sync is a manual replay.
- **34 files differ from upstream by whitespace alone** — permanent merge conflicts for zero functional gain, caused by format-on-save with a newer Prettier than Dawn was authored with.
- **GemPages and PageFly are entirely dead** — `gp-head.liquid` and `pagefly-main-js.liquid` have zero callers, yet PageFly's translation block sits in all 30 locale files.
- **Two `{% schema %}` blocks fail `JSON.parse`** (trailing commas) — tolerated by Shopify today.
- **`locales/it.json` repurposes `powered_by_shopify` to hold the VAT number** — flagged so nobody "corrects" it.
- `scheme-white-text` is genuinely white-on-white; the dated `!important` block in `base.css` patches its symptoms rather than the scheme.

## Tooling

[`agent-browser`](https://github.com/vercel-labs/agent-browser) as a **local devDependency**, matching the repo's rule that nothing is installed globally.

```sh
npm run dev                                   # background it
npm run shot -- /products/doiy-sweetie-mug    # writes a PNG, prints the path
```

`scripts/shot.mjs` handles what this store needs every time: dismissing the cookie banner, setting the viewport, waiting for the page to settle, and reporting console errors. Flags for `--mobile` / `--tablet`, `--full`, `--dark`, and `--live`.

`npm run browser -- <cmd>` exposes the full CLI for interaction, accessibility snapshots, and `diff screenshot` visual regression.

## Doc upkeep enforcement

`AGENTS.md` carries the protocol (a trigger table, plus "replace, don't accumulate"). A `Stop` hook in `.claude/settings.json` makes it fire rather than stay aspirational — **at most once per session**, and only when theme files changed while docs did not. It explicitly says not to invent a doc change to satisfy the check, so routine edits stay quiet.

## Verification

Run against the live dev server, not just written:

- Local screenshot of a product page — the custom `variant_sku` and `qty_disclaimer` blocks render as documented
- `?view=` template switching returns a different page
- Hot reload picks up a CSS edit with no restart (reverted afterwards)
- `npm run check`: **45 warnings, 0 errors** — unchanged from before this branch

Two corrections made during the work: an initial claim that agents were blocked on Shopify OAuth was wrong (the session caches in `~/.config/shopify-cli-kit-nodejs/`, not `~/.config/shopify/`), and my first `.shopifyignore` additions used bare trailing slashes, which the CLI warns about — switched to `dir/*`, which also silenced a pre-existing warning.

## Not included

The drift backlog in `ARCHITECTURE.md` §3 is documented but **not acted on** — deleting dead GemPages/PageFly files, fixing the schema commas, and re-syncing the drifted layouts are all separate changes. This PR is docs and tooling only; no Liquid, CSS, or JS behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)